### PR TITLE
Date header for email reports

### DIFF
--- a/weberror/reporter.py
+++ b/weberror/reporter.py
@@ -6,6 +6,7 @@ from email.MIMEMultipart import MIMEMultipart
 import smtplib
 import time
 from weberror import formatter
+from email.utils import formatdate
 
 class Reporter(object):
 
@@ -93,6 +94,7 @@ class EmailReporter(Reporter):
         msg['Subject'] = as_str(self.subject_prefix) + subject
         msg['From'] = as_str(self.from_address)
         msg['To'] = as_str(', '.join(self.to_addresses))
+        msg['Date'] = formatdate()
         return msg
 
 class LogReporter(Reporter):


### PR DESCRIPTION
Hi, the emails from WebError lack Date header (result is that in my case they end up unsorted in the far end of the inbox). Probably you did not notice it because the header can be added automatically by SMTP server, but it is not always the case and this patch is trivial.
