### PR TITLE
Fix CSRF validation when token is unicode

### DIFF
--- a/weberror/util/security.py
+++ b/weberror/util/security.py
@@ -51,4 +51,4 @@ def valid_csrf_token(secret, token):
 
     expected = hmac.new(secret, expiry_ts, hashlib.sha256).hexdigest()
 
-    return constant_time_compare(hashed, expected)
+    return constant_time_compare(str(hashed), expected)


### PR DESCRIPTION
Pramid's params can be either str or unicode depending on the encoding.
Without this fix, constant_time_compare gives a TypeError: 'unicode' does
not have the buffer interface.